### PR TITLE
allow support for PDB file sizes > 4GB

### DIFF
--- a/Source/Windows/MSF/SuperBlock.cs
+++ b/Source/Windows/MSF/SuperBlock.cs
@@ -154,6 +154,7 @@ namespace SharpPdb.Windows.MSF
                 case 1024:
                 case 2048:
                 case 4096:
+                case 8192:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
Linker flag `/pdbpagesize:8192` makes it possible to produce a PDB > 4GB.
Therefore, 8192 is now a valid block size.


https://reviews.llvm.org/D115051